### PR TITLE
update selectItemAddress

### DIFF
--- a/BDTHPlugin/PluginMemory.cs
+++ b/BDTHPlugin/PluginMemory.cs
@@ -155,7 +155,7 @@ namespace BDTHPlugin
         layoutWorldPtr = Marshal.ReadIntPtr(layoutWorldPtr);
 
         // Select housing item.
-        selectItemAddress = Plugin.TargetModuleScanner.ScanText("E8 ?? ?? 00 00 48 8B CE E8 ?? ?? 00 00 48 8B ?? ?? ?? 48");
+        selectItemAddress = Plugin.TargetModuleScanner.ScanText("48 85 D2 0F 84 49 09 00 00 53 41 56 48 83 EC 48 48 89 6C 24 60 48 8B DA 48 89 74 24 70 4C 8B F1");
         SelectItem = Marshal.GetDelegateForFunctionPointer<SelectItemDelegate>(selectItemAddress);
 
         // Address for the place item function.


### PR DESCRIPTION
This restores the functionality of selecting items from the BDTH item menue. There does exist an issue where if a new item is selected from the plugin menue the original items position wil revert if the position update was not finalized by manually de-selecting the original item by clicking off it in-game.